### PR TITLE
Sensor self-test

### DIFF
--- a/OpenCO2_Mini.ino
+++ b/OpenCO2_Mini.ino
@@ -15,7 +15,7 @@ float humidity = 0.0f;
 uint16_t sensorStatus = 0;
 static int64_t lastMeasurementTimeMs = 0;
 
-#define FIRMWARE_VERSION "v1.5"
+#define FIRMWARE_VERSION "v1.6"
 
 #define BUTTON GPIO_NUM_0
 #define SCL GPIO_NUM_13
@@ -197,6 +197,32 @@ void setup() {
   }
 #endif /* ENABLE_SERIAL_PRINTS */
   delay(100);
+
+  uint16_t testResult = 0;
+  error = sensor.performSelfTest(testResult);
+  if (error) {
+    // Communication error -> Raspberry
+    pixels.setPixelColor(0, pixels.Color(255, 0, 125));
+    pixels.show();
+    esp_light_sleep_start();
+  }
+  if (testResult) {
+    if (testResult & (1 << 0)) {
+      // Supply voltage issue -> Magenta
+      pixels.setPixelColor(0, pixels.Color(255, 0, 255));
+    } else if (testResult & (1 << 4)) {
+      // SHT Sensor not connected -> Violet
+      pixels.setPixelColor(0, pixels.Color(125, 0, 255));
+    } else if (testResult & (1 << 5) || testResult & (1 << 6)) {
+      // Memory error -> Cyan
+      pixels.setPixelColor(0, pixels.Color(0, 255, 255));
+    } else {
+      // Unknown/debug bits -> White
+      pixels.setPixelColor(0, pixels.Color(255, 255, 255));
+    }
+    pixels.show();
+    esp_light_sleep_start();
+  }
 
   // Perform conditioning to ensure good performance
   error = sensor.performConditioning();


### PR DESCRIPTION
Update firmware version to v1.6 and add a sensor self-test during setup. The code calls sensor.performSelfTest() and handles communication errors and test result bits by setting the status pixel to different colors: Raspberry-> communication error;
Magenta -> supply voltage issue;
Violet-> SHT Sensor not connected;
Cyan-> Memory error;
White-> other;
And entering light sleep to halt operation on failure. This surfaces hardware faults early and prevents normal operation when the sensor reports problems.